### PR TITLE
feat: add support for boot args as a first class entity

### DIFF
--- a/src/generated/machine_config_pkg_schema.ts
+++ b/src/generated/machine_config_pkg_schema.ts
@@ -30,6 +30,12 @@ export interface Processor {
   stval?: StringGuhVuclw;
   stvec?: StringGuhVuclw;
 }
+export type Args = string;
+export type BootPrefix = string;
+export interface Boot {
+  args: Args;
+  bootPrefix?: BootPrefix;
+}
 export type StringDoaGddGA = string;
 export interface Ram {
   length: StringGuhVuclw;
@@ -37,7 +43,6 @@ export interface Ram {
   resolvedPath?: StringDoaGddGA;
 }
 export interface Rom {
-  bootargs: StringDoaGddGA;
   cid: StringDoaGddGA;
   resolvedPath?: StringDoaGddGA;
 }
@@ -63,6 +68,7 @@ export interface Drive {
 export type FlashDrive = Drive[];
 export interface PackageMachineConfig {
   processor?: Processor;
+  boot: Boot;
   ram: Ram;
   rom: Rom;
   htif?: Htif;

--- a/src/machine-config-package-schema.json
+++ b/src/machine-config-package-schema.json
@@ -5,293 +5,344 @@
     "type": "object",
     "$ref": "#/definitions/package",
     "definitions": {
-      "package": {
-          "type": "object",
-          "title": "cartiPackage",
-          "properties": {
-              "machineConfig": {
-                  "$ref": "#/definitions/packageMachineConfig"
-              },
-              "assets": {
-                  "$ref": "#/definitions/assets"
-              },
-              "version": {
-                  "$ref": "#/definitions/version"
-              },
-              "metadata": {
-                  "$ref": "#/definitions/metadata"
-              }
-          },
-          "required": ["machineConfig", "assets", "version"]
-      },
-      "version": {
-          "title": "version"
-      },
-      "metadata": {
-          "type":"object",
-          "title": "metadata",
-          "properties": {
-              "projectName": {
-                  "title": "projectName",
-                  "type": "string"
-              }
-          }
-      },
-      "assets": {
-          "type": "array",
-          "title": "assets",
-          "items":{
-              "$ref": "#/definitions/asset"
-          }
-      },
-      "asset": {
-          "type": "object",
-          "title": "asset",
-          "properties": {
-              "name": {
-                  "title": "name",
-                  "type":"string"
-              },
-              "fileName": {
-                  "title": "fileName",
-                  "type":"string"
-              },
-              "cid": {
-                  "title": "cid",
-                  "type": "string"
-              }
-          },
-          "required": ["name","fileName","cid"]
-      },
-      "packageMachineConfig" : {
-        "title": "packageMachineConfig",
-        "type" : "object",
-        "properties" : {
-            "processor": {
-                "$ref": "#/definitions/processor"
+        "package": {
+            "type": "object",
+            "title": "cartiPackage",
+            "properties": {
+                "machineConfig": {
+                    "$ref": "#/definitions/packageMachineConfig"
+                },
+                "assets": {
+                    "$ref": "#/definitions/assets"
+                },
+                "version": {
+                    "$ref": "#/definitions/version"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/metadata"
+                }
             },
-            "ram": {
-                "$ref": "#/definitions/ram"
-            },
-            "rom": {
-                "$ref": "#/definitions/rom"
-            },
-            "htif": {
-                "$ref": "#/definitions/htif"
-            },
-            "clint": {
-                "$ref": "#/definitions/clint"
-            },
-            "flash_drive": {
-               "$ref": "#/definitions/flash_drive"
+            "required": [
+                "machineConfig",
+                "assets",
+                "version"
+            ]
+        },
+        "version": {
+            "title": "version"
+        },
+        "metadata": {
+            "type": "object",
+            "title": "metadata",
+            "properties": {
+                "projectName": {
+                    "title": "projectName",
+                    "type": "string"
+                }
             }
         },
-        "required": ["ram", "rom", "flash_drive"],
-        "additionalProperties": false
-      },
-      "processor": {
-          "type": "object",
-          "title": "processor",
-          "properties": {
-              "x" : {
-                  "$ref": "#/definitions/x"
-              },
-              "iflags": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "ilrsc": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "marchid": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "mcause": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "mcounteren": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "mcycle": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "medeleg": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "mepc": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "mideleg": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "mie": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "mimpid": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "minstret" : {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "mip": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "misa": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "mscratch": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "mstatus": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "mtval": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "mtvec": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "mvendorid": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "pc": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "satp": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "scause": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "scounteren": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "sepc": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "sscratch": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "stval": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "stvec": {
-                  "$ref": "#/definitions/HexNumber"
-              }
-          },
-          "required": [ ],
-          "additionalProperties": false
-      },
-      "ram": {
-          "title": "ram",
-          "type": "object",
-          "properties": {
-              "length": {
-                  "$ref" : "#/definitions/HexNumber"
-              },
-              "cid": {
-                  "type": "string"
-              },
-              "resolvedPath": {
-                "type": "string"
-             }
-          },
-          "required": ["length", "cid"],
-          "additionalProperties": false
-      },
-      "rom": {
-          "type": "object",
-        "title": "rom",
-        "properties": {
-           "bootargs": {
-            "type": "string"   
-           }, 
-            "cid": {
-                "type":"string"
-            },
-            "resolvedPath": {
-                "type": "string"
+        "assets": {
+            "type": "array",
+            "title": "assets",
+            "items": {
+                "$ref": "#/definitions/asset"
             }
         },
-          "required": ["cid", "bootargs"],
-          "additionalProperties": false
-      },
-      "htif": {
-          "type": "object",
-          "title":"htif",
-          "properties": {
-              "tohost": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "fromhost": {
-                  "$ref": "#/definitions/HexNumber"
-              },
-              "console_getchar":{
-                  "type": "boolean"
-              },
-              "yield_progress":{
-                  "type": "boolean"
-              },
-              "yield_rollup":{
-                  "type": "boolean"
-              }
-          },
-          "required": ["tohost","fromhost","console_getchar", "yield_progress", "yield_rollup"],
-          "additionalProperties": false
-      },
-      "clint":{
-          "type": "object",
-          "title": "clint",
-          "properties" :{
-              "mtimecmp" : {
-                  "$ref": "#/definitions/HexNumber"
-              }
-          },
-          "required": ["mtimecmp"],
-          "additionalProperties": false
-      },
-      "flash_drive": {
-          "title": "flash_drive",
-          "type": "array",
-          "items": {
-              "$ref": "#/definitions/Drive"
-          }
-      },
-      "Drive": {
-        "type": "object",
-        "title":"drive",
-        "properties": {
-            "start": {
+        "asset": {
+            "type": "object",
+            "title": "asset",
+            "properties": {
+                "name": {
+                    "title": "name",
+                    "type": "string"
+                },
+                "fileName": {
+                    "title": "fileName",
+                    "type": "string"
+                },
+                "cid": {
+                    "title": "cid",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "fileName",
+                "cid"
+            ]
+        },
+        "packageMachineConfig": {
+            "title": "packageMachineConfig",
+            "type": "object",
+            "properties": {
+                "processor": {
+                    "$ref": "#/definitions/processor"
+                },
+                "boot": {
+                    "$ref": "#/definitions/boot"
+                },
+                "ram": {
+                    "$ref": "#/definitions/ram"
+                },
+                "rom": {
+                    "$ref": "#/definitions/rom"
+                },
+                "htif": {
+                    "$ref": "#/definitions/htif"
+                },
+                "clint": {
+                    "$ref": "#/definitions/clint"
+                },
+                "flash_drive": {
+                    "$ref": "#/definitions/flash_drive"
+                }
+            },
+            "required": [
+                "boot",
+                "ram",
+                "rom",
+                "flash_drive"
+            ],
+            "additionalProperties": false
+        },
+        "processor": {
+            "type": "object",
+            "title": "processor",
+            "properties": {
+                "x": {
+                    "$ref": "#/definitions/x"
+                },
+                "iflags": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "ilrsc": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "marchid": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "mcause": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "mcounteren": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "mcycle": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "medeleg": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "mepc": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "mideleg": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "mie": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "mimpid": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "minstret": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "mip": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "misa": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "mscratch": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "mstatus": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "mtval": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "mtvec": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "mvendorid": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "pc": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "satp": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "scause": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "scounteren": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "sepc": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "sscratch": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "stval": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "stvec": {
+                    "$ref": "#/definitions/HexNumber"
+                }
+            },
+            "required": [],
+            "additionalProperties": false
+        },
+        "ram": {
+            "title": "ram",
+            "type": "object",
+            "properties": {
+                "length": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "cid": {
+                    "type": "string"
+                },
+                "resolvedPath": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "length",
+                "cid"
+            ],
+            "additionalProperties": false
+        },
+        "boot": {
+            "type": "object",
+            "title": "boot",
+            "properties": {
+                "args": {
+                    "$ref": "#/definitions/args"
+                },
+                "bootPrefix": {
+                    "$ref": "#/definitions/bootPrefix"
+                }   
+            },
+            "required": ["args"],
+            "additionalProperties": false
+        },
+        "rom": {
+            "type": "object",
+            "title": "rom",
+            "properties": {
+                "cid": {
+                    "type": "string"
+                },
+                "resolvedPath": {
+                    "type": "string"
+                }
+            },
+            "required": ["cid"],
+            "additionalProperties": false
+        },
+        "htif": {
+            "type": "object",
+            "title": "htif",
+            "properties": {
+                "tohost": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "fromhost": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "console_getchar": {
+                    "type": "boolean"
+                },
+                "yield_progress": {
+                    "type": "boolean"
+                },
+                "yield_rollup": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "tohost",
+                "fromhost",
+                "console_getchar",
+                "yield_progress",
+                "yield_rollup"
+            ],
+            "additionalProperties": false
+        },
+        "clint": {
+            "type": "object",
+            "title": "clint",
+            "properties": {
+                "mtimecmp": {
+                    "$ref": "#/definitions/HexNumber"
+                }
+            },
+            "required": [
+                "mtimecmp"
+            ],
+            "additionalProperties": false
+        },
+        "flash_drive": {
+            "title": "flash_drive",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/Drive"
+            }
+        },
+        "Drive": {
+            "type": "object",
+            "title": "drive",
+            "properties": {
+                "start": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "length": {
+                    "$ref": "#/definitions/HexNumber"
+                },
+                "cid": {
+                    "type": "string"
+                },
+                "resolvedPath": {
+                    "type": "string"
+                },
+                "shared": {
+                    "type": "boolean"
+                },
+                "label": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "start",
+                "length",
+                "shared",
+                "label"
+            ],
+            "additionalProperties": false
+        },
+        "x": {
+            "title": "x",
+            "type": "array",
+            "items": {
                 "$ref": "#/definitions/HexNumber"
-            },
-            "length": {
-                "$ref": "#/definitions/HexNumber"
-            },
-            "cid": {
-                "type": "string"
-            },
-            "resolvedPath": {
-                "type": "string"
-            },
-            "shared": {
-                "type": "boolean"
-            },
-            "label": {
-                "type": "string"
             }
         },
-        "required": ["start","length","shared", "label"],
-        "additionalProperties": false
-      },
-      "x": {
-          "title": "x",
-          "type":"array",
-          "items":{
-              "$ref": "#/definitions/HexNumber"
-          }
-      },
-      "HexNumber": {
-          "type":"string",
-          "pattern": "^0x[a-fA-F\\d]+$"
-      }
+        "HexNumber": {
+            "type": "string",
+            "pattern": "^0x[a-fA-F\\d]+$"
+        },
+        "args": {
+            "title": "args",
+            "type": "string"
+        },
+        "bootPrefix": {
+            "title": "bootPrefix",
+            "type": "string"
+        }
     }
 }

--- a/src/packager/bundle.ts
+++ b/src/packager/bundle.ts
@@ -6,7 +6,7 @@ import { binMemEncoder } from "./package_encoders"
 import { Fetcher } from "../fetcher";
 import { CID } from "multiformats"
 import { readableByteStreamToBuffer } from "../encoders";
-export type BundleType = "ram" | "rom" | "raw" | "flashdrive"
+export type BundleType = "ram" | "rom" | "flashdrive" | "raw" 
 
 export interface BundleMeta {
     name: string

--- a/src/packager/index.test.ts
+++ b/src/packager/index.test.ts
@@ -21,6 +21,7 @@ describe("packing function test", () => {
         let machineConfig = await luaParser.parseLuaMachineConfig(testLua.toString())
         const storage = new Storage(new MemoryProvider())
         const pkgConfig = await pack(machineConfig, storage);
+        console.log(JSON.stringify(pkgConfig,null,2))
         expect(pkgConfig.assets.length === 3).true
     })
 

--- a/src/packager/machine.test.ts
+++ b/src/packager/machine.test.ts
@@ -14,7 +14,7 @@ describe("tests package config object management", () => {
         }
     }
     // TODO add more exhaustive tests
-    it.only("should crud a carti package object", () => {
+    it("should crud a carti package object", () => {
 
         const flashBundle1 = dummyBundle("flashdrive", "flash")
         const flashBundle2 = dummyBundle("flashdrive", "flash2")
@@ -39,12 +39,13 @@ describe("tests package config object management", () => {
         expect(flashDrive.length === "0x900").true
         expect(flashDrive.start === "0x1000").true
 
-        config = cartiPackage.updatePackageEntry(romBundle, config, { bootargs: "hello world" })
+        config = cartiPackage.updatePackageEntry(romBundle, config, {})
         config = cartiPackage.updatePackageEntry(ramBundle, config, { length: "0x450" })
+        config = cartiPackage.setPackageBoot(config, "hello world")
         expect(config.assets.length === 4).true
         expect(config.machineConfig.rom.cid === "rom-cid").true
         expect(config.machineConfig.ram.cid === "ram-cid").true
         expect(config.machineConfig.ram.length === "0x450").true
-        expect(config.machineConfig.rom.bootargs === "hello world").true
+        expect(config.machineConfig.boot.args === "hello world").true
     })
 })


### PR DESCRIPTION
Previously bootargs were embedded into rom, this causes
some problems because bootargs in lua config dictates
flash drive labels, and vice versa for going from
machine package to lua config.

The change here makes it possible to parse labels
from drives and have a consistent restoration and
storage of boot args in a predictable manner

bootargs in rom in lua config will always be dynamic
in the sense that it is either a concatenation of
prefix || or a computed prefix value that is
detailed by the machine emulator in in code comments