### PR TITLE
fix: this corrects escaping on all fields

### DIFF
--- a/src/packager/index.test.ts
+++ b/src/packager/index.test.ts
@@ -1,6 +1,6 @@
 import { install, pack } from "../packager"
 import * as luaParser from '../parser/lua_parser';
-import fs from 'fs-extra';
+import fs, { writeJSONSync } from 'fs-extra';
 import { Storage } from "../storage"
 import { expect } from "chai";
 import { MemoryProvider } from "../storage/memory";
@@ -11,6 +11,7 @@ import util from "util"
 const rmAll = util.promisify(rimraf);
 
 import {testTemplateLuaConfig} from "../parser/test_template_config";
+import { generateLuaConfig } from "..";
 const testLua = testTemplateLuaConfig(`${__dirname}/../fixtures`)
 
 
@@ -26,17 +27,19 @@ describe("packing function test", () => {
     })
 
     //TODO more exhaustive test here for proper installation
-    it("should install a package config", async () => {
+    it.only("should install a package config", async () => {
         let machineConfig = await luaParser.parseLuaMachineConfig(testLua.toString())
         const storage = new Storage(new MemoryProvider())
         const pkgConfig = await pack(machineConfig, storage);
         const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tmp-carti-p'))
+        // TODO more exhaustive quote test for boot args
+        // Test relies on default atm this just injects new args
+        pkgConfig.machineConfig.boot = { args: "echo 'Hello World'" }
         const cfg = await install(pkgConfig, storage, dir, "/opt/carti/packages")
-        console.log(`${dir}/baenrwigfd3thblxcse7nvzwsebphtfre5nsmfl3wymz5n3jgi3aqwhsocy/rom.bin`)
         let example = fs.readFileSync(`${dir}/baenrwigfd3thblxcse7nvzwsebphtfre5nsmfl3wymz5n3jgi3aqwhsocy/rom.bin`)
         expect(cfg.rom.image_filename === '/opt/carti/packages/baenrwigfd3thblxcse7nvzwsebphtfre5nsmfl3wymz5n3jgi3aqwhsocy/rom.bin')
-        console.log(Buffer.from(example).toString())
         expect(Buffer.from(example).toString() === "fakerom").true
+        fs.writeFile(`${dir}`, JSON.stringify(pkgConfig, null, 2))
         await rmAll(dir)
         return
     })

--- a/src/parser/lua_config_template.ts
+++ b/src/parser/lua_config_template.ts
@@ -17,7 +17,7 @@ ${outerIndent}},
 const condVarTemplate = (val: any, varName: string, indent = 0, quote = false): string => {
   const bodyIndent = ' '.repeat(indent + 2)
   const q = quote ? '"' : ""
-  const value = `${bodyIndent}${varName} = ${q}<%- ${varName} %>${q},`
+  const value = `${bodyIndent}${varName} = ${q}<%= ${varName} %>${q},`
   const condTemplate = `
    <% if (typeof(${varName}) !== "undefined") {%>
      ${value}


### PR DESCRIPTION
there was bug in the templates where the escape for html flag
was enabled on conditional template values, this had the
effect of escaping quotes, breaking config in different
context