### PR TITLE
fix: this resolves an issue with bundleless flash drives

### DIFF
--- a/src/packager/index.test.ts
+++ b/src/packager/index.test.ts
@@ -27,7 +27,7 @@ describe("packing function test", () => {
     })
 
     //TODO more exhaustive test here for proper installation
-    it.only("should install a package config", async () => {
+    it("should install a package config", async () => {
         let machineConfig = await luaParser.parseLuaMachineConfig(testLua.toString())
         const storage = new Storage(new MemoryProvider())
         const pkgConfig = await pack(machineConfig, storage);

--- a/src/parser/lua_config_template.ts
+++ b/src/parser/lua_config_template.ts
@@ -1,18 +1,19 @@
 import { MachineConfig } from "../generated/machine_config_schema";
 import _ from "lodash";
 
+//${bodyIndent}image_filename = "<%- image_filename %>",
 const flashDriveTemplate = (drive: any, indent = 6): string => {
   const bodyIndent = ' '.repeat(indent + 2)
   const outerIndent = ' '.repeat(indent)
   const fdriveTemplate = `${outerIndent}{
 ${bodyIndent}start = <%- start %>,
 ${bodyIndent}length = <%- length %>,
-${bodyIndent}image_filename = "<%- image_filename %>",
+${bodyIndent}<%= condVarTemplate(image_filename, "image_filename", 1, true) %>
 ${bodyIndent}shared = <%- shared %>,
 ${outerIndent}},
 `
   const compiled = _.template(fdriveTemplate)
-  return compiled(drive)
+  return compiled({...drive, condVarTemplate})
 }
 const condVarTemplate = (val: any, varName: string, indent = 0, quote = false): string => {
   const bodyIndent = ' '.repeat(indent + 2)


### PR DESCRIPTION
so if you just have label and length the machine config
template parser will correctly generate a lua config